### PR TITLE
fix: locale selector active state on sub-pages (legal pages)

### DIFF
--- a/js/locale.js
+++ b/js/locale.js
@@ -13,13 +13,19 @@
   // Normalise current pathname to always have trailing slash
   var currentPath = window.location.pathname.replace(/\/?$/, '/');
 
+  // For sub-pages (e.g. /fr/pp.html/), derive the locale root path (/fr/)
+  var localePath = LABELS[currentPath] ? currentPath : (function () {
+    var m = currentPath.match(/^(\/[^/]+\/)/);
+    return (m && LABELS[m[1]]) ? m[1] : '/';
+  }());
+
   // Set current label in nav button
   var labelEl = document.getElementById('navLocaleLabel');
-  if (labelEl) labelEl.textContent = LABELS[currentPath] || 'EN';
+  if (labelEl) labelEl.textContent = LABELS[localePath] || 'EN';
 
   // Mark active option in dropdown
   document.querySelectorAll('.locale-opt').forEach(function (opt) {
-    if (opt.dataset.localePath === currentPath) {
+    if (opt.dataset.localePath === localePath) {
       opt.classList.add('locale-opt--active');
       opt.setAttribute('aria-selected', 'true');
     }


### PR DESCRIPTION
## Summary

- On legal pages (`/fr/pp.html`, `/fr/tos.html`, etc.) the nav locale button was displaying **EN** and marking no option as active in the dropdown
- Root cause: `locale.js` matched `window.location.pathname` directly against the `LABELS` map, which only contains locale root paths (`/fr/`, `/de/`, …) — sub-page paths never matched
- Fix: derive the locale root path by extracting the first path segment as a fallback when the full path isn't found in `LABELS`

## Test plan

- [ ] Visit `/fr/pp.html` — nav locale button should show **FR** with the French option active in the dropdown
- [ ] Visit `/de/tos.html` — should show **DE**
- [ ] Visit `/` (root) — still shows **EN** as before
- [ ] Visit `/fr/` (locale home) — still shows **FR** as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)